### PR TITLE
ci: don't publish as build plugin

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -34,7 +34,3 @@ jobs:
         if: ${{ steps.release.outputs.release_created }}
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-      - uses: netlify/submit-build-plugin-action@v1
-        if: ${{ steps.release.outputs.release_created }}
-        with:
-          github-token: ${{ steps.get-token.outputs.token }}


### PR DESCRIPTION
This is not a build plugin, so shouldn;t have the "submit build plugin" action